### PR TITLE
⚡ Bolt: Add database filtering and indexing for calendar events

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -187,6 +187,8 @@ model CalendarEvent {
 
   users CalendarEventUser[]
 
+  @@index([start])
+  @@index([end])
   @@map("calendar_events")
 }
 

--- a/server/api/calendar-events/index.get.ts
+++ b/server/api/calendar-events/index.get.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import consola from "consola";
 import ical from "ical.js";
 
@@ -86,6 +87,17 @@ export default defineEventHandler(async (event) => {
     const endDate = query.end ? new Date(query.end as string) : new Date(now.getFullYear() + 2, now.getMonth(), now.getDate());
 
     const events = await prisma.calendarEvent.findMany({
+      where: {
+        AND: [
+          { start: { lte: endDate } },
+          {
+            OR: [
+              { ical_event: { not: Prisma.DbNull } },
+              { end: { gte: startDate } },
+            ],
+          },
+        ],
+      },
       select: {
         id: true,
         title: true,


### PR DESCRIPTION
💡 What: Added database-level filtering for calendar events by date range and added indexes on `start` and `end` columns.
🎯 Why: The previous implementation fetched all calendar events from the database and filtered them in memory, which is inefficient and scales poorly (O(N) for all events).
📊 Impact: Reduces database load and payload size significantly. Query complexity becomes proportional to the number of events in the requested window (plus recurring events) rather than total history.
🔬 Measurement: Verified with a script that the new query correctly filters non-recurring events by date range and includes recurring events.

---
*PR created automatically by Jules for task [12856279209977285397](https://jules.google.com/task/12856279209977285397) started by @DeRusto*