### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack in PIN verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,9 @@
 **Vulnerability:** Parent PIN was stored in plaintext in the database (`household_settings` table), allowing anyone with database access to view the PIN.
 **Learning:** The schema comment said "// Encrypted PIN", but the implementation used simple string comparison. Always verify implementation matches comments/documentation.
 **Prevention:** Use `scrypt` or similar hashing algorithms to hash sensitive data before storage. Implemented a migration strategy to lazily hash legacy PINs upon next verification.
+
+## 2026-01-28 - [Timing Attack in PIN Verification]
+
+**Vulnerability:** Legacy plaintext PIN verification used `===` for string comparison, allowing timing attacks to guess the PIN character by character.
+**Learning:** Even when migrating to secure hashes, the backward compatibility layer for legacy data must also be secure. `Buffer.from()` throws on non-string inputs, creating a DoS vector if not guarded.
+**Prevention:** Use constant-time comparison (e.g., `crypto.timingSafeEqual`) for all secret comparisons, including legacy fallbacks. Ensure input types are strictly validated before creating Buffers.

--- a/scripts/testSecurityUtils.ts
+++ b/scripts/testSecurityUtils.ts
@@ -1,4 +1,4 @@
-import { hashPin, verifyPin } from "../server/utils/security";
+import { hashPin, timingSafeStringEqual, verifyPin } from "../server/utils/security";
 
 /* eslint-disable no-console */
 async function runTests() {
@@ -39,6 +39,23 @@ async function runTests() {
   // Test 5: Verify invalid hash format
   const isGarbageInvalid = await verifyPin(pin, "garbage");
   assert(!isGarbageInvalid, "Rejects garbage hash");
+
+  // Test 6: Timing safe string equal - equal strings
+  const isEqual = timingSafeStringEqual("test", "test");
+  assert(isEqual, "timingSafeStringEqual returns true for equal strings");
+
+  // Test 7: Timing safe string equal - different strings same length
+  const isDifferent = timingSafeStringEqual("test", "best");
+  assert(!isDifferent, "timingSafeStringEqual returns false for different strings");
+
+  // Test 8: Timing safe string equal - different lengths
+  const isDifferentLength = timingSafeStringEqual("test", "testing");
+  assert(!isDifferentLength, "timingSafeStringEqual returns false for different lengths");
+
+  // Test 9: Timing safe string equal - invalid types
+  // @ts-expect-error testing invalid type
+  const isInvalidType = timingSafeStringEqual("test", 123);
+  assert(!isInvalidType, "timingSafeStringEqual returns false for invalid types");
 
   console.log(`\nTests completed. Passed: ${passed}, Failed: ${failed}`);
   if (failed > 0) {

--- a/server/api/household/verifyPin.post.ts
+++ b/server/api/household/verifyPin.post.ts
@@ -7,7 +7,7 @@ type VerifyPinBody = {
 export default defineEventHandler(async (event) => {
   const body = await readBody<VerifyPinBody>(event);
 
-  if (!body.pin) {
+  if (!body.pin || typeof body.pin !== "string") {
     throw createError({
       statusCode: 400,
       statusMessage: "PIN is required",
@@ -27,7 +27,7 @@ export default defineEventHandler(async (event) => {
   let isValid = await verifyPin(body.pin, settings.parentPin);
 
   // Migration: If verification failed, check if it's a legacy plaintext PIN
-  if (!isValid && settings.parentPin === body.pin) {
+  if (!isValid && timingSafeStringEqual(settings.parentPin, body.pin)) {
     isValid = true;
 
     // Upgrade to hashed PIN

--- a/server/utils/security.ts
+++ b/server/utils/security.ts
@@ -19,6 +19,29 @@ export async function hashPin(pin: string): Promise<string> {
 }
 
 /**
+ * Compares two strings in constant time (for equal lengths).
+ * Returns false if lengths differ (not constant time for length check).
+ */
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  if (typeof a !== "string" || typeof b !== "string") {
+    return false;
+  }
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+
+  try {
+    return timingSafeEqual(bufA, bufB);
+  }
+  catch {
+    return false;
+  }
+}
+
+/**
  * Verifies a PIN against a stored hash.
  * Returns false if the hash format is invalid or verification fails.
  */


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix timing attack in PIN verification

**Severity:** HIGH
**Vulnerability:** The legacy PIN verification used `===` for string comparison, which is susceptible to timing attacks. This could allow an attacker to guess the PIN character by character.
**Fix:** Introduced a `timingSafeStringEqual` utility that uses `crypto.timingSafeEqual` to compare strings in constant time (relative to content). Replaced the insecure comparison with this utility. Also added input validation to prevent DoS via type errors.
**Verification:** Added unit tests in `scripts/testSecurityUtils.ts` covering the new utility and edge cases (different lengths, invalid types). Ran tests using `npx jiti scripts/testSecurityUtils.ts`.

---
*PR created automatically by Jules for task [17970793221904196652](https://jules.google.com/task/17970793221904196652) started by @DeRusto*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PIN verification with timing-safe comparison to prevent potential timing-based attacks
  * Strengthened input validation for PIN values to reject non-string inputs
  * Optimized legacy PIN migration to use secure comparison methods

* **Tests**
  * Added comprehensive test coverage for timing-safe string comparison functionality, including edge cases and type validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->