### PR TITLE
Fix responsive UI inconsistency by making useBreakpoint a singleton

### DIFF
--- a/app/composables/useBreakpoint.ts
+++ b/app/composables/useBreakpoint.ts
@@ -1,7 +1,9 @@
-export function useBreakpoint() {
-  const isDesktop = ref(true);
+const isDesktop = ref(true);
+let initialized = false;
 
-  if (import.meta.client) {
+export function useBreakpoint() {
+  if (import.meta.client && !initialized) {
+    initialized = true;
     const query = window.matchMedia("(min-width: 1024px)");
     isDesktop.value = query.matches;
 
@@ -9,10 +11,6 @@ export function useBreakpoint() {
       isDesktop.value = e.matches;
     };
     query.addEventListener("change", handler);
-
-    onScopeDispose(() => {
-      query.removeEventListener("change", handler);
-    });
   }
 
   const isMobile = computed(() => !isDesktop.value);


### PR DESCRIPTION
Refactored `app/composables/useBreakpoint.ts` to implement the Singleton pattern, ensuring `isDesktop` state is shared globally and initialized only once. This fixes the issue where the app would display in a letterbox on mobile devices while showing mobile navigation.

---
*PR created automatically by Jules for task [3000592260351113901](https://jules.google.com/task/3000592260351113901) started by @DeRusto*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized initialization logic for improved performance and reduced redundant setup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->