### PR TITLE
Fix Immich and Google Photos integration dialog layout

### DIFF
--- a/app/components/settings/settingsGoogleCalendarSelector.vue
+++ b/app/components/settings/settingsGoogleCalendarSelector.vue
@@ -111,7 +111,7 @@ function toggleCalendar(calendarId: string) {
       <UIcon name="i-lucide-loader-2" class="animate-spin h-6 w-6 text-muted" />
     </div>
 
-    <div v-else-if="calendars.length > 0" class="space-y-2 max-h-[300px] overflow-y-auto">
+    <div v-else-if="calendars.length > 0" class="space-y-2">
       <div
         v-for="calendar in calendars"
         :key="calendar.id"

--- a/app/components/settings/settingsImmichAlbumSelector.vue
+++ b/app/components/settings/settingsImmichAlbumSelector.vue
@@ -169,7 +169,7 @@ function deselectAll() {
     </div>
 
     <!-- Album Grid with Thumbnails -->
-    <div v-else class="max-h-80 overflow-y-auto">
+    <div v-else>
       <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
         <div
           v-for="album in albums"

--- a/app/components/settings/settingsImmichPeopleSelector.vue
+++ b/app/components/settings/settingsImmichPeopleSelector.vue
@@ -206,7 +206,7 @@ const petsSelected = computed(() => selectedPeopleIds.value.filter(id => pets.va
         </div>
       </div>
 
-      <div class="max-h-60 overflow-y-auto">
+      <div>
         <div class="grid grid-cols-3 sm:grid-cols-4 gap-3">
           <div
             v-for="person in people"
@@ -278,7 +278,7 @@ const petsSelected = computed(() => selectedPeopleIds.value.filter(id => pets.va
         </div>
       </div>
 
-      <div class="max-h-60 overflow-y-auto">
+      <div>
         <div class="grid grid-cols-3 sm:grid-cols-4 gap-3">
           <div
             v-for="pet in pets"

--- a/app/components/settings/settingsIntegrationDialog.vue
+++ b/app/components/settings/settingsIntegrationDialog.vue
@@ -584,19 +584,8 @@ function handleDelete() {
         </div>
       </template>
 
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-2">
-          <UCheckbox
-            v-model="enabled"
-            label="Enable integration"
-          />
-        </div>
-      </div>
-    </div>
-
-    <!-- Integration Specific Footer Content -->
-    <template #footer-left>
-      <div v-if="service === 'google-photos' && integration?.id" class="p-4 border-t border-default bg-muted/5 w-full">
+      <!-- Integration Specific Settings -->
+      <div v-if="service === 'google-photos' && integration?.id" class="pt-6 border-t border-default">
         <settingsGooglePhotosAlbumSelector
           :integration-id="integration.id"
           :access-token="integration.accessToken || ''"
@@ -605,7 +594,7 @@ function handleDelete() {
         />
       </div>
 
-      <div v-if="service === 'immich' && integration?.id" class="p-4 border-t border-default bg-muted/5 w-full space-y-4">
+      <div v-if="service === 'immich' && integration?.id" class="pt-6 border-t border-default space-y-8">
         <settingsImmichAlbumSelector
           :integration-id="integration.id"
           :selected-albums="(settingsData.selectedAlbums as string[]) || []"
@@ -617,6 +606,15 @@ function handleDelete() {
           @people-selected="handleImmichPeopleSelected"
         />
       </div>
-    </template>
+
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <UCheckbox
+            v-model="enabled"
+            label="Enable integration"
+          />
+        </div>
+      </div>
+    </div>
   </GlobalDialog>
 </template>


### PR DESCRIPTION
The Immich photos integration dialog was malformed because the album and people selection areas were placed in the footer slot of the GlobalDialog, causing them to be squished and scroll independently from the rest of the form.

This change:
1.  Moves these selectors into the main scrollable body of the `settingsIntegrationDialog.vue`.
2.  Removes `max-h` and `overflow-y-auto` from `settingsImmichAlbumSelector.vue`, `settingsImmichPeopleSelector.vue`, and `settingsGoogleCalendarSelector.vue`.
3.  Ensures that the "Enable integration" checkbox stays at the bottom of the form for a logical layout.

These changes fix the "squished" appearance and provide a much better user experience, especially on mobile where the dialog is full-screen.

---
*PR created automatically by Jules for task [17104238418369784144](https://jules.google.com/task/17104238418369784144) started by @DeRusto*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed height restrictions and scroll limitations from calendar list and album selector components to improve visibility
  * Enhanced People and Pets selector sections by removing fixed-height constraints for better content display
  * Reorganized integration settings dialog with restructured section layout, improved spacing, and repositioned enable toggle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->