### PR TITLE
refactor: replace mutating reorderTodo optimistic update with non-mut…

### DIFF
--- a/app/composables/useTodos.ts
+++ b/app/composables/useTodos.ts
@@ -211,9 +211,12 @@ export function useTodos() {
             const currentTodoInCache = todos.value.find(t => t.id === todoId);
             const targetTodoInCache = todos.value.find(t => t.id === targetTodo.id);
             if (currentTodoInCache && targetTodoInCache) {
-              const tempOrder = currentTodoInCache.order;
-              currentTodoInCache.order = targetTodoInCache.order;
-              targetTodoInCache.order = tempOrder;
+              const updatedTodos = todos.value.map(t => {
+                if (t.id === todoId) return { ...t, order: targetTodoInCache.order };
+                if (t.id === targetTodo.id) return { ...t, order: currentTodoInCache.order };
+                return t;
+              });
+              todos.value.splice(0, todos.value.length, ...updatedTodos);
             }
           }
         },


### PR DESCRIPTION
…ating map/splice

The optimistic apply callback for reorderTodo was directly mutating order properties on objects inside todos.value. Replace with a map that produces new todo objects with swapped order values, then assign the resulting array via splice — consistent with how clearCompleted and other operations work.

https://claude.ai/code/session_01M5n8oVKMzewQStuUMtQX3q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the todo reordering functionality to improve reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->