### PR TITLE
fix: enforce exact 4-digit numeric PIN validation

### DIFF
--- a/app/components/settings/settingsPinChangeDialog.vue
+++ b/app/components/settings/settingsPinChangeDialog.vue
@@ -49,6 +49,11 @@ async function handleSave() {
     return;
   }
 
+  if (props.hasAdultPin && !/^\d{4}$/.test(currentPin.value)) {
+    error.value = "Current PIN must be exactly 4 numeric digits";
+    return;
+  }
+
   if (!newPin.value) {
     error.value = "Please enter a new PIN";
     return;

--- a/app/components/settings/settingsPinDialog.vue
+++ b/app/components/settings/settingsPinDialog.vue
@@ -39,6 +39,11 @@ async function handleVerify() {
     return;
   }
 
+  if (!/^\d{4}$/.test(pin.value)) {
+    error.value = "PIN must be exactly 4 numeric digits";
+    return;
+  }
+
   isVerifying.value = true;
   error.value = "";
 

--- a/server/api/household/settings.put.ts
+++ b/server/api/household/settings.put.ts
@@ -64,7 +64,7 @@ export default defineEventHandler(async (event) => {
       hashedPin = null;
     }
     else {
-      if (!/^\d{4}$/.test(body.adultPin)) {
+      if (typeof body.adultPin !== "string" || !/^\d{4}$/.test(body.adultPin)) {
         throw createError({
           statusCode: 400,
           statusMessage: "PIN must be exactly 4 numeric digits",


### PR DESCRIPTION
Fixes #62

## Summary

- The PIN change dialog allowed setting PINs with "at least 4 digits" and no numeric-only restriction, but the verify endpoint requires exactly 4 numeric digits. Any PIN set outside this constraint could never be verified.
- Added client-side and server-side format validation to enforce exactly 4 numeric digits when setting a PIN.
- Added `maxlength`, `inputmode="numeric"`, and `pattern` to all PIN inputs for consistent UX.

## Test plan

- [ ] Set a household PIN via Settings > Change PIN
- [ ] Verify that non-numeric or 5+ digit entries are rejected with a clear error
- [ ] Unlock integrations using the correct 4-digit PIN
- [ ] Verify incorrect PIN shows "Incorrect PIN"

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PIN validation now requires exactly 4 numeric digits for current, new, and confirm fields.
  * Updated UI copy (headers, subtitles, placeholders, and error messages) to clarify the 4-digit PIN requirement.
  * Added input constraints to PIN fields (maxlength, numeric input guidance and pattern) to prevent invalid entries and enable numeric keypad on mobile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->