### PR TITLE
⚡ optimize reorder API endpoints with prisma.$transaction

### DIFF
--- a/server/api/shopping-list-items/reorder.put.ts
+++ b/server/api/shopping-list-items/reorder.put.ts
@@ -11,14 +11,14 @@ export default defineEventHandler(async (event) => {
     const body = await readBody(event);
     const { itemIds } = await reorderSchema.parseAsync(body);
 
-    const updatePromises = itemIds.map((id: string, index: number) =>
-      prisma.shoppingListItem.update({
-        where: { id },
-        data: { order: index },
-      }),
+    await prisma.$transaction(
+      itemIds.map((id: string, index: number) =>
+        prisma.shoppingListItem.update({
+          where: { id },
+          data: { order: index },
+        }),
+      ),
     );
-
-    await Promise.all(updatePromises);
 
     return { success: true };
   }

--- a/server/api/shopping-lists/reorder.put.ts
+++ b/server/api/shopping-lists/reorder.put.ts
@@ -11,14 +11,14 @@ export default defineEventHandler(async (event) => {
     const body = await readBody(event);
     const { listIds } = await reorderSchema.parseAsync(body);
 
-    const updatePromises = listIds.map((id: string, index: number) =>
-      prisma.shoppingList.update({
-        where: { id },
-        data: { order: index },
-      }),
+    await prisma.$transaction(
+      listIds.map((id: string, index: number) =>
+        prisma.shoppingList.update({
+          where: { id },
+          data: { order: index },
+        }),
+      ),
     );
-
-    await Promise.all(updatePromises);
 
     return { success: true };
   }

--- a/server/api/todos/reorder.put.ts
+++ b/server/api/todos/reorder.put.ts
@@ -11,14 +11,14 @@ export default defineEventHandler(async (event) => {
     const body = await readBody(event);
     const { todoIds } = await reorderSchema.parseAsync(body);
 
-    const updatePromises = todoIds.map((id: string, index: number) =>
-      prisma.todo.update({
-        where: { id },
-        data: { order: index },
-      }),
+    await prisma.$transaction(
+      todoIds.map((id: string, index: number) =>
+        prisma.todo.update({
+          where: { id },
+          data: { order: index },
+        }),
+      ),
     );
-
-    await Promise.all(updatePromises);
 
     return { success: true };
   }


### PR DESCRIPTION
### 💡 What:
Optimized several reorder API endpoints by replacing `Promise.all` of individual `prisma.update` calls with a single `prisma.$transaction`.

Affected endpoints:
- `server/api/shopping-list-items/reorder.put.ts`
- `server/api/shopping-lists/reorder.put.ts`
- `server/api/todos/reorder.put.ts`

### 🎯 Why:
The previous implementation used `Promise.all` which, while executing updates in parallel from the application's perspective, resulted in an N+1 query pattern where each update was a separate database transaction/connection. Using `prisma.$transaction` batches these updates into a single atomic operation, which is more efficient and prevents partial updates if one operation fails.

### 📊 Measured Improvement:
While a formal benchmark was attempted, network and environment constraints in the sandbox prevented execution of a standalone script. However, this is a standard optimization in Prisma applications to reduce connection pool pressure and ensure data consistency during bulk updates.

The codebase already follows this pattern in other reorder endpoints like `server/api/todo-columns/reorder.put.ts`, and these changes bring consistency to the rest of the reordering logic.

---
*PR created automatically by Jules for task [9310064964052513189](https://jules.google.com/task/9310064964052513189) started by @DeRusto*