### PR TITLE
Define TODO Capabilities

### DIFF
--- a/app/integrations/integrationConfig.ts
+++ b/app/integrations/integrationConfig.ts
@@ -355,9 +355,13 @@ export const integrationConfigs: IntegrationConfig[] = [
   },
   // ================================================
   // TODO integration configs can support the following list-level capabilities:
+  // - get_todos: Can get todos from the integration
+  // - add_todos: Can add new todos to the integration
+  // - edit_todos: Can edit existing todos in the integration
+  // - complete_todos: Can complete/uncomplete todos in the integration
+  // - delete_todos: Can delete todos from the integration
   // ================================================
   // TODO: Add TODO integration configs
-  // TODO: Define TODO capabilities
   // ================================================
 ];
 


### PR DESCRIPTION
Added documentation for TODO integration capabilities (get_todos, add_todos, edit_todos, complete_todos, delete_todos) in integrationConfig.ts and removed placeholder TODOs.

---
*PR created automatically by Jules for task [14647962661762436450](https://jules.google.com/task/14647962661762436450) started by @DeRusto*